### PR TITLE
Add option to include tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
         cmake \
           -S "${GITHUB_WORKSPACE}" \
           -B "${BUILD_DIR}" \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DBUILD_TESTING=ON
       env:
         CC: ${{matrix.cc}}
         CXX: ${{matrix.cxx}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.17)
 set(MORE_CONCEPTS_VERSION 0.1.1)
 project(MoreConcepts VERSION "${MORE_CONCEPTS_VERSION}")
 
-enable_testing()
-add_subdirectory(tests)
+option(BUILD_TESTING "Build the testing tree." OFF)
+if(BUILD_TESTING)
+	enable_testing()
+	add_subdirectory(tests)
+endif()
 
 add_library(more_concepts INTERFACE)
 add_library(more_concepts::more_concepts ALIAS more_concepts)

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,10 +30,14 @@ class MoreConcepts(ConanFile):
     def build(self):
         cmake = CMake(self)
 
+        do_test = tools.get_env("CONAN_RUN_TESTS", True)
+        if(do_test):
+            cmake.definitions["BUILD_TESTING"] = True
+
         cmake.configure()
         cmake.build()
 
-        if tools.get_env("CONAN_RUN_TESTS", True):
+        if(do_test):
             cmake.test()
 
     def package(self):


### PR DESCRIPTION
`BUILD_TESTING` option is used whether to include and enable testing or not.

It's an already existing option that can be set beforehand and to `OFF` by default, so users of the library do not need to include tests.

See: [enable_testing](https://cmake.org/cmake/help/latest/command/enable_testing.html?highlight=build_testing)