### PR TITLE
(Fixed) Add cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,16 @@ install(EXPORT MoreConceptsTargets
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfig.cmake"
 	INSTALL_DESTINATION lib/cmake
 )
 write_basic_package_version_file(
-	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfigVersion.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfigVersion.cmake"
 	VERSION ${MORE_CONCEPTS_VERSION}
 	COMPATIBILITY AnyNewerVersion
 )
 install(FILES
-	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfig.cmake"
-	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfigVersion.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfigVersion.cmake"
 	DESTINATION lib/cmake
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(more_concepts::more_concepts ALIAS more_concepts)
 target_compile_features(more_concepts INTERFACE cxx_std_20)
 set_property(TARGET more_concepts PROPERTY VERSION ${MORE_CONCEPTS_VERSION})
 target_include_directories(more_concepts INTERFACE
-	$<BUILD_INTERFACE:include>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:include>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,38 @@ endif()
 add_library(more_concepts INTERFACE)
 add_library(more_concepts::more_concepts ALIAS more_concepts)
 target_compile_features(more_concepts INTERFACE cxx_std_20)
-target_include_directories(more_concepts INTERFACE include)
+set_property(TARGET more_concepts PROPERTY VERSION ${MORE_CONCEPTS_VERSION})
+target_include_directories(more_concepts INTERFACE
+	$<BUILD_INTERFACE:include>
+	$<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS more_concepts
+	EXPORT MoreConceptsTargets
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION bin
+	INCLUDES DESTINATION include
+)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION .)
+install(EXPORT MoreConceptsTargets
+	FILE MoreConceptsTargets.cmake
+	NAMESPACE more_concepts::
+	DESTINATION lib/cmake
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfig.cmake"
+	INSTALL_DESTINATION lib/cmake
+)
+write_basic_package_version_file(
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfigVersion.cmake"
+	VERSION ${MORE_CONCEPTS_VERSION}
+	COMPATIBILITY AnyNewerVersion
+)
+install(FILES
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsTargetsConfigVersion.cmake"
+	DESTINATION lib/cmake
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ install(EXPORT MoreConceptsTargets
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
 	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfig.cmake"
-	INSTALL_DESTINATION lib/cmake
+	INSTALL_DESTINATION .
 )
 write_basic_package_version_file(
 	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfigVersion.cmake"
@@ -44,5 +44,5 @@ write_basic_package_version_file(
 install(FILES
 	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfig.cmake"
 	"${CMAKE_CURRENT_BINARY_DIR}/MoreConceptsConfigVersion.cmake"
-	DESTINATION lib/cmake
+	DESTINATION .
 )

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,5 +1,5 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/MoreConceptsTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/lib/cmake/MoreConceptsTargets.cmake")
 
 check_required_components(more_concepts)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/MoreConceptsTargets.cmake")
+
+check_required_components(more_concepts)


### PR DESCRIPTION
Apparently relative paths in generator expressions are [not valid](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_INCLUDE_DIRECTORIES.html) for the build tree.

I have activated the github actions and tested the last commit, it passes. It will be good to enable it for PRs from forks too.